### PR TITLE
Add Version field and fix an accessor bug

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Alessandro Zummo <a.zummo@towertech.it>
+David Ihnen <davidihnen@gmail.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2014-06-24 David Ihnen
+  * v1.3
+
+  * add required version field to packets
+
 2013-08-24 Alessandro Zummo
 	* v1.2
 

--- a/lib/Amazon/SNS.pm
+++ b/lib/Amazon/SNS.pm
@@ -106,7 +106,7 @@ sub dispatch
 
 	my $response = LWP::UserAgent->new->post($self->service, 'Content' => $uri->query);
 
-	$self->status_code = $response->code;
+	$self->status_code( $response->code );
 
         if ($response->is_success) {
 		return XMLin($response->content,

--- a/lib/Amazon/SNS.pm
+++ b/lib/Amazon/SNS.pm
@@ -12,7 +12,7 @@ use XML::Simple;
 use URI::Escape;
 use Digest::SHA qw(hmac_sha256_base64);
 
-our $VERSION = '1.2';
+our $VERSION = '1.3';
 
 
 sub CreateTopic
@@ -85,6 +85,7 @@ sub dispatch
 	$args->{'AWSAccessKeyId'} = $self->key;
 	$args->{'SignatureVersion'} = 2;
 	$args->{'SignatureMethod'} = 'HmacSHA256';
+	$args->{'Version'} = '2010-03-31';
 
 	# build URI
 	my $uri = URI->new($self->service);


### PR DESCRIPTION
Primarily, protocol was violated without any Version field for the API.  Added it.

I was getting a warning 'status_code is not an lvalue subroutine', so I threw that in there too.

David
