### PR TITLE
Use to_json to fix mojibake

### DIFF
--- a/lib/Amazon/SNS.pm
+++ b/lib/Amazon/SNS.pm
@@ -200,7 +200,7 @@ sub Publish
 	if (ref($msg) eq 'HASH') {
 
 		$structure = 'json';
-		$msg = encode_json($msg);
+		$msg = to_json($msg);
 	}
 
 
@@ -250,7 +250,7 @@ sub Publish
 	if (ref($msg) eq 'HASH') {
 
 		$structure = 'json';
-		$msg = encode_json($msg);
+		$msg = to_json($msg);
 	}
 
 	if (defined($attr) and ref($attr) eq 'HASH') {


### PR DESCRIPTION
I was troubled with multi-byte characters _mojibake_. To fix it, use `to_json` instead of `encode_json`.

[`encode_json`](https://metacpan.org/pod/JSON#encode_json) converts given flagged UTF8 strings to binary strings internally, but [`uri_escape_utf8`](https://metacpan.org/pod/URI::Escape#uri_escape_utf8-string) expects flagged strings. Thus, I think that [`to_json`](https://metacpan.org/pod/JSON#to_json) (it is equivalent of `encode_json` without decode characters) was preferred here.