### PR TITLE
Adding GetEndpointAttributes and DeleteTopic

### DIFF
--- a/lib/Amazon/SNS.pm
+++ b/lib/Amazon/SNS.pm
@@ -63,6 +63,22 @@ sub GetTarget
 	});
 }
 
+sub GetEndpointAttributes
+{
+	my ($self, $arn) = @_;
+
+	my $r = $self->dispatch({
+		'Action' => 'GetEndpointAttributes',
+		'EndpointArn' => $arn,
+	});
+
+	my $entry = $r->{'GetEndpointAttributesResult'}{'Attributes'}{'entry'};
+
+	return map {
+		$_ => $entry->{$_}->{value}
+	} keys %{$entry};
+}
+
 sub DeleteTopic
 {
 	my ($self, $arn) = @_;
@@ -70,6 +86,16 @@ sub DeleteTopic
 	return $self->dispatch({
 		'Action'	=> 'DeleteTopic',
 		'TopicArn'	=> $arn,
+	});
+}
+
+sub DeleteEndpoint
+{
+	my ($self, $endpointarn) = @_;
+
+	return $self->dispatch({
+		'Action'	=> 'DeleteEndpoint',
+		'EndpointArn'	=> $endpointarn,
 	});
 }
 


### PR DESCRIPTION
GetEndpointAttributes (http://docs.aws.amazon.com/sns/latest/api/API_GetEndpointAttributes.html)
- Parameter: endpoint arn
- Retrieves the endpoint attributes for a device on one of the supported push notification services, such as GCM and APNS.
- Return a hash object (attribute name\value).

DeleteEndpoint (http://docs.aws.amazon.com/sns/latest/api/API_DeleteEndpoint.html)
- Parameter: endpoint arn
- Deletes the endpoint for a device and mobile app from Amazon SNS.

**EDIT:**
It's not ready. I would like a revision before pushing to master branch.